### PR TITLE
Add aarch64-unknown-linux-musl

### DIFF
--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -11,6 +11,7 @@ on:
         options:
         - "x86_64-unknown-linux-musl"
         - "x86_64-unknown-linux-gnu"
+        - "aarch64-unknown-linux-musl"
         - "aarch64-unknown-linux-gnu"
 
       binary_name:


### PR DESCRIPTION
## Summary

Add `aarch64-unknown-linux-musl` support.

## Context

Our company is using GitLab. 

We are contributing to https://github.com/devcontainers-contrib/features .

During the development we realised that alpine is not supported on Apple Silicon chips.

`PyOxidizer` does support `aarch64-unknown-linux-musl` , so we'd like to add it in the build pipeline.

We won't touch the EC2 related pipelines for this one.

## Linked Issues

- https://github.com/devcontainers-contrib/nanolayer/issues/60