### PR TITLE
Add new regex option to gh-release in order filter source binaries

### DIFF
--- a/nanolayer/cli/install.py
+++ b/nanolayer/cli/install.py
@@ -139,6 +139,7 @@ def install_gh_release_binary(
         None, help="comma separated list of binary names"
     ),
     version: str = "latest",
+    source_binaries_filter_regex: Optional[str] = None,
     lib_name: Optional[str] = None,
     asset_regex: Optional[str] = None,
     bin_location: Optional[str] = None,
@@ -158,6 +159,7 @@ def install_gh_release_binary(
         binary_names=binary_names.split(","),
         lib_name=lib_name,
         bin_location=bin_location,
+        source_binaries_filter_regex=source_binaries_filter_regex,
         lib_location=lib_location,
         version=version,
         asset_regex=asset_regex,

--- a/nanolayer/installers/gh_release/gh_release_installer.py
+++ b/nanolayer/installers/gh_release/gh_release_installer.py
@@ -96,6 +96,7 @@ class GHReleaseInstaller:
         binary_names: List[str],
         lib_name: Optional[str] = None,
         bin_location: Optional[Union[str, Path]] = None,
+        source_binaries_filter_regex: Optional[str] = None,
         lib_location: Optional[Union[str, Path]] = None,
         asset_regex: Optional[str] = None,
         version: str = "latest",
@@ -210,7 +211,7 @@ class GHReleaseInstaller:
                 logger.warning("asset recognized as an archive file")
 
                 archive_member_names = BinaryResolver.resolve(
-                    temp_asset_path, binary_names
+                    temp_asset_path, binary_names, source_binaries_filter_regex
                 )
                 assert len(archive_member_names) == len(
                     binary_names

--- a/nanolayer/installers/gh_release/resolvers/binary_resolver.py
+++ b/nanolayer/installers/gh_release/resolvers/binary_resolver.py
@@ -1,3 +1,4 @@
+import re
 import stat
 from typing import List
 
@@ -33,10 +34,11 @@ class BinaryResolver:
         pass
 
     @classmethod
-    def resolve(cls, archive_path: str, binary_names: List[str]) -> List[str]:
+    def resolve(cls, archive_path: str, binary_names: List[str], source_binaries_filter_regex: str = None) -> List[str]:
         binary_members = []
         with Archive(archive_path) as archive_file:
             # resolve target member name
+            archive_file: Archive = archive_file
             if len(archive_file.get_file_members()) == 1:
                 if len(binary_names) > 1:
                     raise cls.BinaryResolverError(
@@ -48,6 +50,13 @@ class BinaryResolver:
             else:
                 for binary_name in binary_names:
                     target_member_names = archive_file.names_by_filename(binary_name)
+
+                    if source_binaries_filter_regex:
+                        target_member_names = [
+                            name for name in target_member_names
+                            if re.match(source_binaries_filter_regex, name)
+                        ]
+
                     if len(target_member_names) > 1:
                         # try narrow it down to single binary using filters
                         filtered_target_member_names = list(


### PR DESCRIPTION
I was having an issue when using the gh-release devcontainer feature in order to install a release that contains multiple binaries with the same name. With this new option I allow filtering those out with a regex.