### PR TITLE
Fix OCIRegistry.WWW_AUTHENTICATE_REGEX in /nanolayer/utils/oci_registry.py

### DIFF
--- a/nanolayer/utils/oci_registry.py
+++ b/nanolayer/utils/oci_registry.py
@@ -42,7 +42,7 @@ class OCIRegistry:
         resource: str
         path: str
 
-    WWW_AUTHENTICATE_REGEX = r'.*[Ww]ww-[Aa]uthenticate:\sBearer\srealm="([\w:/\.]+)",service="([\w:/\.]+)",scope="([\w:/\-,]+)".*'
+    WWW_AUTHENTICATE_REGEX = r'.*[Ww]{3}-[Aa]uthenticate:\sBearer\srealm="([\w:/\.]+)",service="([\w:/\.]+)",scope="([\w:/\-,]+)".*'
 
     @staticmethod
     def parse_oci(oci_input: str) -> "OCIRegistry.ParsedOCIRef":


### PR DESCRIPTION
This PR addresses an issue with OCIRegistry.WWW_AUTHENTICATE_REGEX. The WWW-Authenticate header can be provided with all uppercase “WWW”, but the current implementation only allows the first character to be uppercase (``[Ww]ww``). This fix ensures that the regex correctly handles the WWW-Authenticate header regardless of the case.