### PR TITLE
Fix resolve aarch64 to ARM64

### DIFF
--- a/nanolayer/installers/gh_release/resolvers/asset_resolver.py
+++ b/nanolayer/installers/gh_release/resolvers/asset_resolver.py
@@ -23,7 +23,7 @@ class AssetResolver:
         LinuxInformationDesk.Architecture.I386: r"(i386|\-386|_386)",
         LinuxInformationDesk.Architecture.I686: r"(i686|\-686|_686)",
         LinuxInformationDesk.Architecture.ARM32: r"([Aa]rm32|ARM32)",
-        LinuxInformationDesk.Architecture.ARM64: r"([Aa]rm64|ARM64)",
+        LinuxInformationDesk.Architecture.ARM64: r"([Aa]rm64|ARM64)|(aarch64)",
         LinuxInformationDesk.Architecture.S390: r"(s390x|s390)",
         LinuxInformationDesk.Architecture.PPC64: r"(\-ppc|ppc64|PPC64|_ppc)",
         LinuxInformationDesk.Architecture.x86_64: r"([Aa]md64|\-x64|x64|x86[_-]64)",

--- a/tests/installers/gh_release/test_gh_release_installer.py
+++ b/tests/installers/gh_release/test_gh_release_installer.py
@@ -215,6 +215,15 @@ from helpers import execute_current_python_in_container
             "",
             "linux/arm64",
         ),
+        (
+            "rg --version",
+            0,
+            "mcr.microsoft.com/vscode/devcontainers/python:3.10-bullseye",
+            "BurntSushi/ripgrep",
+            "rg",
+            "",
+            "linux/arm64",
+        ),
     ],
 )
 def test_gh_release_install(


### PR DESCRIPTION
When using nanolayer with devcontainer features, some Github Releases use `aarch64` instead of `ARM64` in their releases.

I encountered this problem with `ripgrep`
https://github.com/BurntSushi/ripgrep/releases

See output below.  `nanolayer` was not able to resolve this correctly and mistakenly chose `ppc64` which was not compatible with my system.

```
'ripgrep-14.1.1-aarch64-apple-darwin.tar.gz' filtered by '([Mm]ac[Oo][Ss]|[Mm]ac\-[Oo][Ss]|\-osx\-|_osx_|[Dd]arwin|\.dmg)' (negative)
'ripgrep-14.1.1-aarch64-apple-darwin.tar.gz.sha256' filtered by '(\.sig$|\.text$|\.txt$|[Cc]hecksums|sha256|\.sha1$|\.md5$)' (negative)
'ripgrep-14.1.1-aarch64-unknown-linux-gnu.tar.gz.sha256' filtered by '(\.sig$|\.text$|\.txt$|[Cc]hecksums|sha256|\.sha1$|\.md5$)' (negative)
'ripgrep-14.1.1-armv7-unknown-linux-gnueabihf.tar.gz' filtered by '([Aa][Rr][Mm]v7)' (negative)
'ripgrep-14.1.1-armv7-unknown-linux-gnueabihf.tar.gz.sha256' filtered by '([Aa][Rr][Mm]v7)' (negative)
'ripgrep-14.1.1-armv7-unknown-linux-musleabi.tar.gz' filtered by '([Aa][Rr][Mm]v7)' (negative)
'ripgrep-14.1.1-armv7-unknown-linux-musleabi.tar.gz.sha256' filtered by '([Aa][Rr][Mm]v7)' (negative)
'ripgrep-14.1.1-armv7-unknown-linux-musleabihf.tar.gz' filtered by '([Aa][Rr][Mm]v7)' (negative)
'ripgrep-14.1.1-armv7-unknown-linux-musleabihf.tar.gz.sha256' filtered by '([Aa][Rr][Mm]v7)' (negative)
'ripgrep-14.1.1-i686-pc-windows-msvc.zip' filtered by '(i686|\-686|_686)' (negative)
'ripgrep-14.1.1-i686-pc-windows-msvc.zip.sha256' filtered by '(i686|\-686|_686)' (negative)
'ripgrep-14.1.1-i686-unknown-linux-gnu.tar.gz' filtered by '(i686|\-686|_686)' (negative)
'ripgrep-14.1.1-i686-unknown-linux-gnu.tar.gz.sha256' filtered by '(i686|\-686|_686)' (negative)
'ripgrep-14.1.1-powerpc64-unknown-linux-gnu.tar.gz.sha256' filtered by '(\.sig$|\.text$|\.txt$|[Cc]hecksums|sha256|\.sha1$|\.md5$)' (negative)
'ripgrep-14.1.1-s390x-unknown-linux-gnu.tar.gz' filtered by '(s390x|s390)' (negative)
'ripgrep-14.1.1-s390x-unknown-linux-gnu.tar.gz.sha256' filtered by '(s390x|s390)' (negative)
'ripgrep-14.1.1-x86_64-apple-darwin.tar.gz' filtered by '([Aa]md64|\-x64|x64|x86[_-]64)' (negative)
'ripgrep-14.1.1-x86_64-apple-darwin.tar.gz.sha256' filtered by '([Aa]md64|\-x64|x64|x86[_-]64)' (negative)
'ripgrep-14.1.1-x86_64-pc-windows-gnu.zip' filtered by '([Aa]md64|\-x64|x64|x86[_-]64)' (negative)
'ripgrep-14.1.1-x86_64-pc-windows-gnu.zip.sha256' filtered by '([Aa]md64|\-x64|x64|x86[_-]64)' (negative)
'ripgrep-14.1.1-x86_64-pc-windows-msvc.zip' filtered by '([Aa]md64|\-x64|x64|x86[_-]64)' (negative)
'ripgrep-14.1.1-x86_64-pc-windows-msvc.zip.sha256' filtered by '([Aa]md64|\-x64|x64|x86[_-]64)' (negative)
'ripgrep-14.1.1-x86_64-unknown-linux-musl.tar.gz' filtered by '([Aa]md64|\-x64|x64|x86[_-]64)' (negative)
'ripgrep-14.1.1-x86_64-unknown-linux-musl.tar.gz.sha256' filtered by '([Aa]md64|\-x64|x64|x86[_-]64)' (negative)
'ripgrep_14.1.1-1_amd64.deb' filtered by '([Aa]md64|\-x64|x64|x86[_-]64)' (negative)
'ripgrep_14.1.1-1_amd64.deb.sha256' filtered by '([Aa]md64|\-x64|x64|x86[_-]64)' (negative)
'ripgrep-14.1.1-aarch64-unknown-linux-gnu.tar.gz' filtered by '.*rg.*'
'ripgrep-14.1.1-powerpc64-unknown-linux-gnu.tar.gz' filtered by '.*rg.*'
'ripgrep-14.1.1-aarch64-unknown-linux-gnu.tar.gz' filtered by '([Aa]rm64|ARM64)'
'ripgrep-14.1.1-powerpc64-unknown-linux-gnu.tar.gz' filtered by '([Aa]rm64|ARM64)'
'ripgrep-14.1.1-aarch64-unknown-linux-gnu.tar.gz' filtered by '(?i)(debian)'
'ripgrep-14.1.1-powerpc64-unknown-linux-gnu.tar.gz' filtered by '(?i)(debian)'
'ripgrep-14.1.1-aarch64-unknown-linux-gnu.tar.gz' filtered by '.*static.*'
'ripgrep-14.1.1-powerpc64-unknown-linux-gnu.tar.gz' filtered by '.*static.*'
'ripgrep-14.1.1-aarch64-unknown-linux-gnu.tar.gz' filtered by '(?i)(debian)'
'ripgrep-14.1.1-powerpc64-unknown-linux-gnu.tar.gz' filtered by '(?i)(debian)'
'ripgrep-14.1.1-aarch64-unknown-linux-gnu.tar.gz' filtered by '\-ARM\-?|\-arm\-'
'ripgrep-14.1.1-powerpc64-unknown-linux-gnu.tar.gz' filtered by '\-ARM\-?|\-arm\-'
'ripgrep-14.1.1-aarch64-unknown-linux-gnu.tar.gz' filtered by '(?i)(arch)' (negative)
resolved asset: ripgrep-14.1.1-powerpc64-unknown-linux-gnu.tar.gz
```